### PR TITLE
feat: add swap button loader and block select token before full load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.9",
+  "version": "1.3.10",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/swap-widget/components.tsx
+++ b/src/swap-widget/components.tsx
@@ -662,6 +662,7 @@ export const TokenAmount = (props: TokenAmountProps) => {
                   style={{
                     whiteSpace: 'nowrap',
                     height: '26px',
+                    userSelect: 'none',
                   }}
                   className="__ref-swap-widget-row-flex-center"
                 >

--- a/src/swap-widget/index.tsx
+++ b/src/swap-widget/index.tsx
@@ -263,6 +263,10 @@ export const SwapWidget = (props: SwapWidgetProps) => {
     slippageTolerance < 100 &&
     !ONLY_ZEROS.test(tokenInBalance);
 
+  const tokensAndBalancesLoaded = useMemo(() => {
+    return tokens.length > 0 && Object.keys(balances).length > 0;
+  }, [tokens, balances]);
+
   return (
     <ThemeContextProvider customTheme={curTheme}>
       <TokenPriceContextProvider>
@@ -316,6 +320,7 @@ export const SwapWidget = (props: SwapWidgetProps) => {
               price={!tokenIn ? null : tokenPriceList?.[tokenIn.id]?.price}
               onChangeAmount={setAmountIn}
               onSelectToken={() => {
+                if (!tokensAndBalancesLoaded) return;
                 setWidgetRoute('token-selector-in');
               }}
             />
@@ -351,6 +356,7 @@ export const SwapWidget = (props: SwapWidgetProps) => {
               token={tokenOut}
               price={!tokenOut ? null : tokenPriceList?.[tokenOut.id]?.price}
               onSelectToken={() => {
+                if (!tokensAndBalancesLoaded) return;
                 setWidgetRoute('token-selector-out');
               }}
               onForceUpdate={() => {
@@ -399,7 +405,11 @@ export const SwapWidget = (props: SwapWidgetProps) => {
                 }}
                 disabled={!canSubmit}
               >
-                {'Swap'}
+                {tokensAndBalancesLoaded ? (
+                  'Swap'
+                ) : (
+                  <div className="__ref-swap-widget-submit-button-loader"></div>
+                )}
               </button>
             ) : (
               <button

--- a/src/swap-widget/index.tsx
+++ b/src/swap-widget/index.tsx
@@ -263,9 +263,9 @@ export const SwapWidget = (props: SwapWidgetProps) => {
     slippageTolerance < 100 &&
     !ONLY_ZEROS.test(tokenInBalance);
 
-  const tokensAndBalancesLoaded = useMemo(() => {
-    return tokens.length > 0 && Object.keys(balances).length > 0;
-  }, [tokens, balances]);
+  const tokensLoaded = useMemo(() => {
+    return tokens.length > 0;
+  }, [tokens]);
 
   return (
     <ThemeContextProvider customTheme={curTheme}>
@@ -320,7 +320,7 @@ export const SwapWidget = (props: SwapWidgetProps) => {
               price={!tokenIn ? null : tokenPriceList?.[tokenIn.id]?.price}
               onChangeAmount={setAmountIn}
               onSelectToken={() => {
-                if (!tokensAndBalancesLoaded) return;
+                if (!tokensLoaded) return;
                 setWidgetRoute('token-selector-in');
               }}
             />
@@ -356,7 +356,7 @@ export const SwapWidget = (props: SwapWidgetProps) => {
               token={tokenOut}
               price={!tokenOut ? null : tokenPriceList?.[tokenOut.id]?.price}
               onSelectToken={() => {
-                if (!tokensAndBalancesLoaded) return;
+                if (!tokensLoaded) return;
                 setWidgetRoute('token-selector-out');
               }}
               onForceUpdate={() => {
@@ -405,7 +405,7 @@ export const SwapWidget = (props: SwapWidgetProps) => {
                 }}
                 disabled={!canSubmit}
               >
-                {tokensAndBalancesLoaded ? (
+                {tokensLoaded ? (
                   'Swap'
                 ) : (
                   <div className="__ref-swap-widget-submit-button-loader"></div>

--- a/src/swap-widget/style.css
+++ b/src/swap-widget/style.css
@@ -168,6 +168,8 @@
 
 .__ref-swap-widget-submit-button {
   width: 100%;
+  display: flex;
+  align-items: center;
   justify-content: center;
   font-size: 18px;
   font-weight: 700;
@@ -176,6 +178,28 @@
   margin-top: 14px;
   cursor: pointer;
 }
+
+.__ref-swap-widget-submit-button-loader {
+  width: 20px;
+  height: 20px;
+  border: 2px solid #fff;
+  border-bottom-color: rgb(255, 255, 255);
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 .__ref-widget-swap-detail-view {
   justify-content: space-between;
   width: 100%;


### PR DESCRIPTION
Fixes the issue when I was able to click on select token without having these tokens loaded.
Add loader icon to swap button to indicate initial loading.

P.S. Maybe we don't have to wait for balances to be fetched. Just tokens list is enough.

before

https://github.com/user-attachments/assets/7f1a5130-f19e-4dca-b786-57379ff5b8ef




after 



https://github.com/user-attachments/assets/8c016dea-ec63-4721-9275-1962b6197234

