### PR TITLE
improve input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.9",
+  "version": "1.3.11",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/swap-widget/components.tsx
+++ b/src/swap-widget/components.tsx
@@ -766,7 +766,7 @@ export const TokenAmount = (props: TokenAmountProps) => {
             className="__ref-swap-widget-input-class"
             value={amount}
             type="text"
-            onKeyDownCapture={handleKeyDown}
+            onKeyDown={handleKeyDown}
             onPaste={handlePaste}
             placeholder={!onChangeAmount ? '-' : '0.0'}
             onChange={({ target }) => {
@@ -774,7 +774,6 @@ export const TokenAmount = (props: TokenAmountProps) => {
               handleChange(target.value);
             }}
             disabled={!onChangeAmount}
-            onKeyDown={e => symbolsArr.includes(e.key) && e.preventDefault()}
             style={{
               color: primary,
               marginBottom: '8px',

--- a/src/swap-widget/components.tsx
+++ b/src/swap-widget/components.tsx
@@ -571,6 +571,25 @@ export const HalfAndMaxAmount = ({
   );
 };
 
+const ALLOWED_KEYS = [
+  'Backspace',
+  'Tab',
+  'ArrowLeft',
+  'ArrowRight',
+  'Delete', // control keys
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9', // numeric keys
+  '.', // decimal point
+];
+
 export const TokenAmount = (props: TokenAmountProps) => {
   const {
     balance,
@@ -601,6 +620,26 @@ export const TokenAmount = (props: TokenAmountProps) => {
   const ref = useRef<HTMLInputElement>(null);
 
   const [hoverSelect, setHoverSelect] = useState<boolean>(false);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!ALLOWED_KEYS.includes(event.key) && !event.ctrlKey) {
+      event.preventDefault();
+    }
+
+    // Ensure only one dot is allowed
+    const inputValue = (event.target as HTMLInputElement).value;
+    if (event.key === '.' && inputValue.includes('.')) {
+      event.preventDefault();
+    }
+  };
+
+  const handlePaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+    const paste = event.clipboardData.getData('text');
+
+    if (!/^[0-9.]+$/.test(paste)) {
+      event.preventDefault();
+    }
+  };
 
   const handleChange = (amount: string) => {
     if (onChangeAmount) {
@@ -719,16 +758,16 @@ export const TokenAmount = (props: TokenAmountProps) => {
           <input
             ref={ref}
             max={!!onChangeAmount ? curMax : undefined}
-            min="0"
             onWheel={() => {
               if (ref.current) {
                 ref.current.blur();
               }
             }}
             className="__ref-swap-widget-input-class"
-            step="any"
             value={amount}
-            type="number"
+            type="text"
+            onKeyDownCapture={handleKeyDown}
+            onPaste={handlePaste}
             placeholder={!onChangeAmount ? '-' : '0.0'}
             onChange={({ target }) => {
               target.setCustomValidity('');

--- a/src/swap-widget/components.tsx
+++ b/src/swap-widget/components.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useEffect, useContext, useRef, useMemo } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useContext,
+  useRef,
+  useMemo,
+  useCallback,
+} from 'react';
 import { TokenMetadata, EstimateSwapView, Pool } from '../types';
 import {
   ThemeContext,
@@ -572,25 +579,35 @@ export const HalfAndMaxAmount = ({
 };
 
 const DECIMAL_POINT = '.';
-const ALLOWED_KEYS = [
-  'Backspace',
-  'Tab',
-  'ArrowLeft',
-  'ArrowRight',
-  'Delete', // control keys
-  '0',
-  '1',
-  '2',
-  '3',
-  '4',
-  '5',
-  '6',
-  '7',
-  '8',
-  '9', // numeric keys
-  DECIMAL_POINT, // decimal point
-];
+const ALLOWED_KEYS: Record<string, boolean> = {
+  '0': true,
+  '1': true,
+  '2': true,
+  '3': true,
+  '4': true,
+  '5': true,
+  '6': true,
+  '7': true,
+  '8': true,
+  '9': true,
+  [DECIMAL_POINT]: true,
+};
 
+const isValidInput = (value: string) => {
+  let decimalPointsAmount = 0;
+  if (value === DECIMAL_POINT) return false;
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (!ALLOWED_KEYS[char]) return false;
+    if (char === DECIMAL_POINT) {
+      decimalPointsAmount++;
+      if (decimalPointsAmount === 2) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
 export const TokenAmount = (props: TokenAmountProps) => {
   const {
     balance,
@@ -621,34 +638,6 @@ export const TokenAmount = (props: TokenAmountProps) => {
   const ref = useRef<HTMLInputElement>(null);
 
   const [hoverSelect, setHoverSelect] = useState<boolean>(false);
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!ALLOWED_KEYS.includes(event.key) && !event.ctrlKey) {
-      event.preventDefault();
-    }
-
-    const isDecimalPoint = event.key === DECIMAL_POINT;
-    if (!isDecimalPoint) return;
-    // Ensure only one dot is allowed
-    const inputValue = (event.target as HTMLInputElement).value;
-    if (inputValue.includes(DECIMAL_POINT)) {
-      event.preventDefault();
-    }
-
-    // prohibit only one dot
-    if (inputValue.length === 0) {
-      event.preventDefault();
-    }
-  };
-
-  const handlePaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
-    const paste = event.clipboardData.getData('text');
-
-    if (!/^[0-9.]+$/.test(paste)) {
-      event.preventDefault();
-    }
-  };
-
   const handleChange = (amount: string) => {
     if (onChangeAmount) {
       onChangeAmount(amount);
@@ -774,10 +763,9 @@ export const TokenAmount = (props: TokenAmountProps) => {
             className="__ref-swap-widget-input-class"
             value={amount}
             type="text"
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
             placeholder={!onChangeAmount ? '-' : '0.0'}
             onChange={({ target }) => {
+              if (!isValidInput(target.value)) return;
               target.setCustomValidity('');
               handleChange(target.value);
             }}

--- a/src/swap-widget/components.tsx
+++ b/src/swap-widget/components.tsx
@@ -571,6 +571,7 @@ export const HalfAndMaxAmount = ({
   );
 };
 
+const DECIMAL_POINT = '.';
 const ALLOWED_KEYS = [
   'Backspace',
   'Tab',
@@ -587,7 +588,7 @@ const ALLOWED_KEYS = [
   '7',
   '8',
   '9', // numeric keys
-  '.', // decimal point
+  DECIMAL_POINT, // decimal point
 ];
 
 export const TokenAmount = (props: TokenAmountProps) => {
@@ -626,9 +627,16 @@ export const TokenAmount = (props: TokenAmountProps) => {
       event.preventDefault();
     }
 
+    const isDecimalPoint = event.key === DECIMAL_POINT;
+    if (!isDecimalPoint) return;
     // Ensure only one dot is allowed
     const inputValue = (event.target as HTMLInputElement).value;
-    if (event.key === '.' && inputValue.includes('.')) {
+    if (inputValue.includes(DECIMAL_POINT)) {
+      event.preventDefault();
+    }
+
+    // prohibit only one dot
+    if (inputValue.length === 0) {
       event.preventDefault();
     }
   };


### PR DESCRIPTION
I can enter text into the input field, plus if  input has problems with diff locale. Comma can reset field in cases when input number wants to use "." as a decimal point

This PR forces input to accept only numbers and control keys (arrows to navigate text and backspace) and impose "." as the only accepted decimal point.

https://github.com/user-attachments/assets/e3f84c3b-7f0b-4642-9994-e22441551538

